### PR TITLE
remove installation of haveged from __schleuder_dependencies 

### DIFF
--- a/tasks/schleuder.yml
+++ b/tasks/schleuder.yml
@@ -7,7 +7,6 @@
   vars:
     __schleuder_dependencies:
       - sqlite3
-      - haveged
 
 - name: install tor
   apt:


### PR DESCRIPTION
not needed on modern linux kernel anymore, entropy generation is much improved, see https://twitter.com/DanielMicay/status/1396956516020805633